### PR TITLE
build: remove mockito-junit-jupiter dependency

### DIFF
--- a/EmployeeManagementSystem/build.gradle
+++ b/EmployeeManagementSystem/build.gradle
@@ -11,10 +11,5 @@ repositories {
 
 dependencies {
     implementation 'junit:junit:4.13.2'
-
-    //mockito 기본 라이브러리
     testImplementation 'org.mockito:mockito-core:4.3.1'
-
-    //mockito , junit 5 연동 라이브러리
-    testImplementation 'org.mockito:mockito-junit-jupiter:4.3.1'
 }


### PR DESCRIPTION
The current codebase of EmployeeManagementSystem does not require the
mockito-junit-jupiter dependency. It became unnecesary when all the test
code was migrated to use the junit library instead of jupiter-junit.

Resolves #54 
Signed-off-by: 김명종 <mj610.kim@gmail.com>