### PR TITLE
Feature/improve database performance

### DIFF
--- a/EmployeeManagementSystem/src/main/java/com/cra08/excellentcode/storage/Database.java
+++ b/EmployeeManagementSystem/src/main/java/com/cra08/excellentcode/storage/Database.java
@@ -6,13 +6,11 @@ import com.cra08.excellentcode.column.IColumn;
 import java.util.*;
 
 public class Database {
-
-    private HashMap<String, Employee> unsortedEmployeeDB;
     TreeMap<String, Employee> employeeDB;
+    LinkedHashMap<String, Employee> employeeDBPerf;
 
     public Database() {
-        unsortedEmployeeDB = new HashMap<>();
-        //employeeDB = new TreeMap<>();
+        employeeDBPerf = new LinkedHashMap<>();
         employeeDB = new TreeMap<>(new SortEmployeeNum<>());
     }
 
@@ -21,6 +19,10 @@ public class Database {
     }
 
     public boolean add(Employee employee) {
+        if (employee == null) {
+            throw new NullPointerException("employee object is null...");
+        }
+
         employeeDB.put(employee.getEmployeeNum(), employee);
         return true;
     }
@@ -45,18 +47,13 @@ public class Database {
     }
 
     public boolean mod(List<Employee> employeeList, IColumn newColName, String newColValue) {
-        if (newColValue.equals("FB NTAWR")) {
-            System.out.println(employeeDB);
-        }
         for (Employee employee : employeeList) {
             employeeDB.put(employee.getEmployeeNum(), newColName.setValue(employee, newColValue));
         }
         return true;
     }
 
-    public boolean sort() {
-        System.out.println("sort");
-
+    public boolean print() {
         Iterator<String> keyIterator = employeeDB.keySet().iterator();
 
         while (keyIterator.hasNext()) {
@@ -64,6 +61,12 @@ public class Database {
         }
 
         return true;
+    }
+
+    public void copyDB() {
+        for (Map.Entry<String, Employee> employee : employeeDB.entrySet()) {
+            employeeDBPerf.put(employee.getKey(), employee.getValue());
+        }
     }
 }
 

--- a/EmployeeManagementSystem/src/main/java/com/cra08/excellentcode/storage/Database.java
+++ b/EmployeeManagementSystem/src/main/java/com/cra08/excellentcode/storage/Database.java
@@ -6,8 +6,9 @@ import com.cra08.excellentcode.column.IColumn;
 import java.util.*;
 
 public class Database {
-    TreeMap<String, Employee> employeeDB;
-    LinkedHashMap<String, Employee> employeeDBPerf;
+    private TreeMap<String, Employee> employeeDB;
+    private LinkedHashMap<String, Employee> employeeDBPerf;
+    private boolean isAddFinished = false;
 
     public Database() {
         employeeDBPerf = new LinkedHashMap<>();
@@ -28,16 +29,18 @@ public class Database {
     }
 
     public boolean del(List<Employee> employeeList) {
+        setAddFinished();
         for (Employee employee : employeeList) {
-            employeeDB.remove(employee.getEmployeeNum());
+            employeeDBPerf.remove(employee.getEmployeeNum());
         }
         return true;
     }
 
     public List<Employee> sch(IColumn colName, String colValue) {
+        setAddFinished();
         List<Employee> resultEmployeeList = new ArrayList<>();
 
-        for (Map.Entry<String, Employee> employee : employeeDB.entrySet()) {
+        for (Map.Entry<String, Employee> employee : employeeDBPerf.entrySet()) {
             if (colName.contains(employee.getValue(), colValue)) {
                 resultEmployeeList.add(employee.getValue());
             }
@@ -47,8 +50,9 @@ public class Database {
     }
 
     public boolean mod(List<Employee> employeeList, IColumn newColName, String newColValue) {
+        setAddFinished();
         for (Employee employee : employeeList) {
-            employeeDB.put(employee.getEmployeeNum(), newColName.setValue(employee, newColValue));
+            employeeDBPerf.put(employee.getEmployeeNum(), newColName.setValue(employee, newColValue));
         }
         return true;
     }
@@ -63,9 +67,16 @@ public class Database {
         return true;
     }
 
-    public void copyDB() {
+    private void copyDB() {
         for (Map.Entry<String, Employee> employee : employeeDB.entrySet()) {
             employeeDBPerf.put(employee.getKey(), employee.getValue());
+        }
+    }
+
+    private void setAddFinished() {
+        if (!isAddFinished) {
+            isAddFinished = true;
+            copyDB();
         }
     }
 }

--- a/EmployeeManagementSystem/src/main/java/com/cra08/excellentcode/storage/Database.java
+++ b/EmployeeManagementSystem/src/main/java/com/cra08/excellentcode/storage/Database.java
@@ -6,17 +6,17 @@ import com.cra08.excellentcode.column.IColumn;
 import java.util.*;
 
 public class Database {
-    private TreeMap<String, Employee> employeeDB;
-    private LinkedHashMap<String, Employee> employeeDBPerf;
+    private TreeMap<String, Employee> employeeDbTree;
+    private LinkedHashMap<String, Employee> employeeDbLinkedHash;
     private boolean isAddFinished = false;
 
     public Database() {
-        employeeDBPerf = new LinkedHashMap<>();
-        employeeDB = new TreeMap<>(new SortEmployeeNum<>());
+        employeeDbLinkedHash = new LinkedHashMap<>();
+        employeeDbTree = new TreeMap<>(new SortEmployeeNum<>());
     }
 
     public int getDatabaseSize() {
-        return employeeDB.size();
+        return employeeDbLinkedHash.size();
     }
 
     public boolean add(Employee employee) {
@@ -24,14 +24,14 @@ public class Database {
             throw new NullPointerException("employee object is null...");
         }
 
-        employeeDB.put(employee.getEmployeeNum(), employee);
+        employeeDbTree.put(employee.getEmployeeNum(), employee);
         return true;
     }
 
     public boolean del(List<Employee> employeeList) {
         setAddFinished();
         for (Employee employee : employeeList) {
-            employeeDBPerf.remove(employee.getEmployeeNum());
+            employeeDbLinkedHash.remove(employee.getEmployeeNum());
         }
         return true;
     }
@@ -40,7 +40,7 @@ public class Database {
         setAddFinished();
         List<Employee> resultEmployeeList = new ArrayList<>();
 
-        for (Map.Entry<String, Employee> employee : employeeDBPerf.entrySet()) {
+        for (Map.Entry<String, Employee> employee : employeeDbLinkedHash.entrySet()) {
             if (colName.contains(employee.getValue(), colValue)) {
                 resultEmployeeList.add(employee.getValue());
             }
@@ -52,13 +52,13 @@ public class Database {
     public boolean mod(List<Employee> employeeList, IColumn newColName, String newColValue) {
         setAddFinished();
         for (Employee employee : employeeList) {
-            employeeDBPerf.put(employee.getEmployeeNum(), newColName.setValue(employee, newColValue));
+            employeeDbLinkedHash.put(employee.getEmployeeNum(), newColName.setValue(employee, newColValue));
         }
         return true;
     }
 
     public boolean print() {
-        Iterator<String> keyIterator = employeeDB.keySet().iterator();
+        Iterator<String> keyIterator = employeeDbTree.keySet().iterator();
 
         while (keyIterator.hasNext()) {
             System.out.println(keyIterator.next());
@@ -67,10 +67,8 @@ public class Database {
         return true;
     }
 
-    private void copyDB() {
-        for (Map.Entry<String, Employee> employee : employeeDB.entrySet()) {
-            employeeDBPerf.put(employee.getKey(), employee.getValue());
-        }
+    public void copyDB() {
+        employeeDbLinkedHash.putAll(employeeDbTree);
     }
 
     private void setAddFinished() {

--- a/EmployeeManagementSystem/src/test/java/com/cra08/excellentcode/storage/DatabaseModTest.java
+++ b/EmployeeManagementSystem/src/test/java/com/cra08/excellentcode/storage/DatabaseModTest.java
@@ -71,7 +71,7 @@ public class DatabaseModTest {
     public void addTest() {
         assertTrue(db.add(mockEmployee1));
         assertTrue(db.add(mockEmployee2));
-        assertTrue(db.sort());
+        assertTrue(db.print());
         assertEquals(2, db.getDatabaseSize());
     }
 

--- a/EmployeeManagementSystem/src/test/java/com/cra08/excellentcode/storage/DatabaseModTest.java
+++ b/EmployeeManagementSystem/src/test/java/com/cra08/excellentcode/storage/DatabaseModTest.java
@@ -72,6 +72,7 @@ public class DatabaseModTest {
         assertTrue(db.add(mockEmployee1));
         assertTrue(db.add(mockEmployee2));
         assertTrue(db.print());
+        db.copyDB();
         assertEquals(2, db.getDatabaseSize());
     }
 

--- a/EmployeeManagementSystem/src/test/java/com/cra08/excellentcode/storage/DatabaseSchTest.java
+++ b/EmployeeManagementSystem/src/test/java/com/cra08/excellentcode/storage/DatabaseSchTest.java
@@ -76,6 +76,7 @@ public class DatabaseSchTest {
         assertTrue(db.add(mockEmployee1));
         assertTrue(db.add(mockEmployee2));
         assertTrue(db.print());
+        db.copyDB();
         assertEquals(2, db.getDatabaseSize());
     }
 

--- a/EmployeeManagementSystem/src/test/java/com/cra08/excellentcode/storage/DatabaseSchTest.java
+++ b/EmployeeManagementSystem/src/test/java/com/cra08/excellentcode/storage/DatabaseSchTest.java
@@ -75,7 +75,7 @@ public class DatabaseSchTest {
     public void addTest() {
         assertTrue(db.add(mockEmployee1));
         assertTrue(db.add(mockEmployee2));
-        assertTrue(db.sort());
+        assertTrue(db.print());
         assertEquals(2, db.getDatabaseSize());
     }
 

--- a/EmployeeManagementSystem/src/test/java/com/cra08/excellentcode/storage/DatabaseSortTest.java
+++ b/EmployeeManagementSystem/src/test/java/com/cra08/excellentcode/storage/DatabaseSortTest.java
@@ -67,7 +67,7 @@ public class DatabaseSortTest {
         assertTrue(db.add(mockEmployee2));
         assertTrue(db.add(mockEmployee3));
         assertTrue(db.add(mockEmployee4));
-        db.print();
+        db.copyDB();
         assertEquals(4, db.getDatabaseSize());
     }
 
@@ -78,6 +78,8 @@ public class DatabaseSortTest {
             db.add(new Employee(employeeNum, "TTT KKK", "CL2",
                     "010-1234-5678", "19900101", "PRO"));
         }
+        db.copyDB();
+        System.out.println(db.getDatabaseSize());
         assertEquals(100000, db.getDatabaseSize());
     }
 
@@ -85,17 +87,6 @@ public class DatabaseSortTest {
     public void addMaxDataTimeoutTest() {
         long startTime = System.currentTimeMillis();
         addMaxDataTest();
-        long endTime = System.currentTimeMillis();
-        System.out.println(endTime - startTime);
-        assertTrue(1000 > endTime - startTime);
-    }
-
-    @Test
-    public void copyDBTest() {
-        addMaxDataTest();
-
-        long startTime = System.currentTimeMillis();
-        db.copyDB();
         long endTime = System.currentTimeMillis();
         System.out.println(endTime - startTime);
         assertTrue(1000 > endTime - startTime);

--- a/EmployeeManagementSystem/src/test/java/com/cra08/excellentcode/storage/DatabaseSortTest.java
+++ b/EmployeeManagementSystem/src/test/java/com/cra08/excellentcode/storage/DatabaseSortTest.java
@@ -67,7 +67,37 @@ public class DatabaseSortTest {
         assertTrue(db.add(mockEmployee2));
         assertTrue(db.add(mockEmployee3));
         assertTrue(db.add(mockEmployee4));
-        db.sort();
+        db.print();
         assertEquals(4, db.getDatabaseSize());
+    }
+
+    @Test
+    public void addMaxDataTest() {
+        for (int i = 0; i < 100000; i++) {
+            String employeeNum = String.valueOf(21000000 + i);
+            db.add(new Employee(employeeNum, "TTT KKK", "CL2",
+                    "010-1234-5678", "19900101", "PRO"));
+        }
+        assertEquals(100000, db.getDatabaseSize());
+    }
+
+    @Test
+    public void addMaxDataTimeoutTest() {
+        long startTime = System.currentTimeMillis();
+        addMaxDataTest();
+        long endTime = System.currentTimeMillis();
+        System.out.println(endTime - startTime);
+        assertTrue(1000 > endTime - startTime);
+    }
+
+    @Test
+    public void copyDBTest() {
+        addMaxDataTest();
+
+        long startTime = System.currentTimeMillis();
+        db.copyDB();
+        long endTime = System.currentTimeMillis();
+        System.out.println(endTime - startTime);
+        assertTrue(1000 > endTime - startTime);
     }
 }

--- a/EmployeeManagementSystem/src/test/java/com/cra08/excellentcode/storage/DatabaseTest.java
+++ b/EmployeeManagementSystem/src/test/java/com/cra08/excellentcode/storage/DatabaseTest.java
@@ -64,7 +64,7 @@ public class DatabaseTest {
         when(mockEmployee2.getCerti()).thenReturn("ADV");
 
         when(mockColumnEmployeeNum.contains(mockEmployee1, "18050301")).thenReturn(true);
-
+        when(mockColumnName.contains(mockEmployee1, "KYUMOK KIM")).thenReturn(true);
         when(mockColumnCl.contains(mockEmployee1, "CL2")).thenReturn(true);
         when(mockColumnPhoneNum.contains(mockEmployee1, "010-9777-6055")).thenReturn(true);
         when(mockColumnBirthday.contains(mockEmployee1, "19980906")).thenReturn(true);
@@ -75,7 +75,7 @@ public class DatabaseTest {
     public void addTest() {
         assertTrue(db.add(mockEmployee1));
         assertTrue(db.add(mockEmployee2));
-        assertTrue(db.print());
+        db.copyDB();
         assertEquals(2, db.getDatabaseSize());
     }
 
@@ -83,6 +83,7 @@ public class DatabaseTest {
     public void addTest_FailCase() {
         assertTrue(db.add(mockEmployee1));
         assertTrue(db.add(mockEmployee2));
+        db.copyDB();
         assertNotEquals(1, db.getDatabaseSize());
     }
 
@@ -90,6 +91,7 @@ public class DatabaseTest {
     public void addTest_NullCase() {
         assertTrue(db.add(mockEmployee1));
         assertTrue(db.add(mockEmployee2));
+        db.copyDB();
 
         assertThrows(NullPointerException.class, () -> db.add(null));
         assertEquals(2, db.getDatabaseSize());
@@ -99,7 +101,6 @@ public class DatabaseTest {
     public void delTest() {
         addTest();
 
-        when(mockColumnName.contains(mockEmployee1, "KYUMOK KIM")).thenReturn(true);
         List<Employee> schResult = db.sch(mockColumnName, "KYUMOK KIM");
         assertEquals(1, schResult.size());
 

--- a/EmployeeManagementSystem/src/test/java/com/cra08/excellentcode/storage/DatabaseTest.java
+++ b/EmployeeManagementSystem/src/test/java/com/cra08/excellentcode/storage/DatabaseTest.java
@@ -3,6 +3,7 @@ package com.cra08.excellentcode.storage;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
@@ -63,7 +64,7 @@ public class DatabaseTest {
         when(mockEmployee2.getCerti()).thenReturn("ADV");
 
         when(mockColumnEmployeeNum.contains(mockEmployee1, "18050301")).thenReturn(true);
-        when(mockColumnName.contains(mockEmployee1, "KYUMOK KIM")).thenReturn(true);
+
         when(mockColumnCl.contains(mockEmployee1, "CL2")).thenReturn(true);
         when(mockColumnPhoneNum.contains(mockEmployee1, "010-9777-6055")).thenReturn(true);
         when(mockColumnBirthday.contains(mockEmployee1, "19980906")).thenReturn(true);
@@ -74,7 +75,7 @@ public class DatabaseTest {
     public void addTest() {
         assertTrue(db.add(mockEmployee1));
         assertTrue(db.add(mockEmployee2));
-        assertTrue(db.sort());
+        assertTrue(db.print());
         assertEquals(2, db.getDatabaseSize());
     }
 
@@ -86,9 +87,19 @@ public class DatabaseTest {
     }
 
     @Test
+    public void addTest_NullCase() {
+        assertTrue(db.add(mockEmployee1));
+        assertTrue(db.add(mockEmployee2));
+
+        assertThrows(NullPointerException.class, () -> db.add(null));
+        assertEquals(2, db.getDatabaseSize());
+    }
+
+    @Test
     public void delTest() {
         addTest();
 
+        when(mockColumnName.contains(mockEmployee1, "KYUMOK KIM")).thenReturn(true);
         List<Employee> schResult = db.sch(mockColumnName, "KYUMOK KIM");
         assertEquals(1, schResult.size());
 


### PR DESCRIPTION
As-is) 삽입 시 정렬은 가능하지만 검색/수정/삭제에 O(log N)이 소요되는 TreeMap
To-be) 검색/수정/삭제에 O(1) 소요되는 LinkedHashMap

input data를 TreeMap에 삽입과 동시에 정렬하다가 input data가 끝나면 LinkedHashMap에 순서대로 재삽입하는 방식으로 진행하였습니다. 

20개 input data는 미세하게 LinkedHashMap의 성능이 아주 조금 더 좋은 것을 확인했습니다. 
퍼포먼스가 실제로 향상되는지는 많은 데이터로 테스트가 필요합니다! 
