### PR TITLE
fix: fix wrong arguments in optionHandler#processOptions at handleModCmd

### DIFF
--- a/EmployeeManagementSystem/src/main/java/com/cra08/excellentcode/CommandHandler.java
+++ b/EmployeeManagementSystem/src/main/java/com/cra08/excellentcode/CommandHandler.java
@@ -145,13 +145,13 @@ public class CommandHandler {
         List<String> optionsList = CommandParser.getOption(input);
 
         printLog("sSearchColName: " + sSearchColName + ", searchColVal: " + searchColVal
-                + ", searchColName: " + sModifyColName + ", sModifyColName: " + modifyColVal
-                + ", modifyColVal: " + Arrays.toString(optionsList.toArray()));
+                + ", sModifyColName: " + sModifyColName + ", modifyColVal: " + modifyColVal
+                + ", optionsList: " + Arrays.toString(optionsList.toArray()));
 
         List<Employee> employeesToMod = database.sch(searchColName, searchColVal);
         OptionHandler optionHandler = new OptionHandler();
-        List<Employee> employeesToModifyFiltered = optionHandler.processOptions(cmd, optionsList, sModifyColName,
-                modifyColVal, employeesToMod);
+        List<Employee> employeesToModifyFiltered = optionHandler.processOptions(cmd, optionsList, sSearchColName,
+                searchColVal, employeesToMod);
 
         database.mod(employeesToModifyFiltered, modifyColName, modifyColVal);
 


### PR DESCRIPTION
The arguments to pass in optionsHnadler.processOptions should be for
column names and values to search, not to modify. This bug caused
incorrect results.

Signed-off-by: 김명종 <mj610.kim@gmail.com>