### PR TITLE
test: add test case for IO module

### DIFF
--- a/EmployeeManagementSystem/src/test/java/com/cra08/excellentcode/io/LocalFileReaderTest.java
+++ b/EmployeeManagementSystem/src/test/java/com/cra08/excellentcode/io/LocalFileReaderTest.java
@@ -3,6 +3,7 @@ package com.cra08.excellentcode.io;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -100,6 +101,11 @@ public class LocalFileReaderTest {
             assertEquals(line, localFileReaderUnderTest.getNextLine());
         }
         assertNull(localFileReaderUnderTest.getNextLine());
+    }
+
+    @Test
+    public void getNextLine_beforeOpening() {
+        assertThrows(NullPointerException.class, () -> localFileReaderUnderTest.getNextLine());
     }
 
     private void createTemporaryInputFile(String folderName, String fileName) throws IOException {

--- a/EmployeeManagementSystem/src/test/java/com/cra08/excellentcode/io/LocalFileWriterTest.java
+++ b/EmployeeManagementSystem/src/test/java/com/cra08/excellentcode/io/LocalFileWriterTest.java
@@ -3,6 +3,7 @@ package com.cra08.excellentcode.io;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
@@ -92,6 +93,11 @@ public class LocalFileWriterTest {
         localFileWriterUnderTest.close();
 
         verifyFile(temporaryDirectory.getPath() + SAMPLE_OUTPUT_FILE_NAME, SAMPLE_OUTPUT_FILE_LINES);
+    }
+
+    @Test
+    public void setNextLine_beforeOpening() {
+        assertThrows(NullPointerException.class, () -> localFileWriterUnderTest.setNextLine(SAMPLE_OUTPUT_FILE_LINES[0]));
     }
 
     private void writeOutput(String[] fileLines) {


### PR DESCRIPTION
Tests for reading/writing before opening was missing from the test
cases. This commit adds those cases.

Signed-off-by: 김명종 <mj610.kim@gmail.com>