### PR TITLE
ci: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @kwonhj0116 @mj610-kim @seongjin-Park210 @taemin00


### PR DESCRIPTION
Add CODEOWNERS file which sets all members of the
EmployeeManagementSystem development team the code owners of every
file inside this repo.

Signed-off-by: 김명종 <mj610.kim@gmail.com>