### PR TITLE
ci: upgrade github actions dependencies

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-java@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: '8'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-java@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: '8'


### PR DESCRIPTION
The GitHub Actions dependencies checkout and setup-java were not the
latest version. Upgrade dependencies to the latest version of v3.0.0.

Signed-off-by: 김명종 <mj610.kim@gmail.com>