### PR TITLE
refactor: modify the isValidCommand to take cmd Enum instead of command array list

### DIFF
--- a/EmployeeManagementSystem/src/main/java/com/cra08/excellentcode/CommandParser.java
+++ b/EmployeeManagementSystem/src/main/java/com/cra08/excellentcode/CommandParser.java
@@ -1,5 +1,7 @@
 package com.cra08.excellentcode;
 
+import com.cra08.excellentcode.datatype.Cmd;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -26,10 +28,8 @@ public class CommandParser {
     }
 
     public static boolean isValidCommand(String cmd) {
-        List<String> validCommands = Arrays.asList("ADD", "DEL", "SCH", "MOD");
-        return validCommands.stream().anyMatch(s -> s.equals(cmd));
+        return Arrays.stream(Cmd.values()).anyMatch(s -> s.name().equals(cmd));
     }
-
 
     public static ArrayList<String> getOption(String cmdLine) {
         ArrayList<String> options = new ArrayList<>(Arrays.asList(parseCommandLine(cmdLine))


### PR DESCRIPTION
Previously, the isValidCommand could deal with only 4 predefined commands. This commit improves the function to deal with any commands defined in cmdEnum.